### PR TITLE
Feat: Handle bulk download of historical Binance data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.DS_Store
+spot/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
-# stock-price-prediction
+# Stock Price Prediction
+An **end-to-end Machine Learning workflow** focused on stock price forecasting. This project encompasses everything from the ML development process to the ML production lifecycle.
+
+
+## 💡 Features
+- Forecasting stock price using Machine Learning
+- Real-time dashboard showing forecasted values
+- Observability dashboard for ML models and their performance
+- Open APIs for data retrieval
+
+
+<!-- ## 💻 Images -->
+
+
+## 🛠️ Tools
+- [**BinanceAPI**](https://github.com/sammchardy/python-binance/tree/master) - for data retrieval from Binance
+- [**MageAI**](https://www.mage.ai/) - for data processing pipeline
+- [**DVC**](https://dvc.org/) - for data versioning control
+- [**PyCaret**](https://pycaret.org/) - for Automated ML model training
+- [**Weights & Biases**](https://wandb.ai/site) - for model experiment tracking
+- [**Aporia's MLNotify**](https://github.com/aporia-ai/mlnotify) - for model training monitoring service ([Aporia official website](https://www.aporia.com/))
+- [**Docker**](https://www.docker.com/) - for system containerization and deployment
+- [**BentoML**](https://github.com/bentoml/BentoML) - for model serving ([BentoML official website](https://www.bentoml.com/))
+- [**Yatai**](https://github.com/bentoml/Yatai) - for model serving at Scale on Kubernetes ([BentoML official website](https://www.bentoml.com/))
+- [**Caddy**](https://caddyserver.com/) - for reverse proxy of services
+- [**Grafana and Prometheus**](https://grafana.com/) - for system, model, hardware observability
+
+
+## 🧩 Components
+- Coming soon
+
+
+## 🌐 Architecture
+<details>
+<summary>System Architecture (coming soon)</summary>
+</details>
+
+<details>
+<summary>Functional Architecture (coming soon)</summary>
+</details>
+
+
+<!-- ## ⚙️ Setting up -->
+<!-- ## 💾 Database -->
+<!-- ## 📊 Data/Payload Schema -->
+
+
+# 🚀 ML Workflow Overview
+## 1. Data Collection
+
+**Data Sources:**
+- [Binance Data Dumper](https://github.com/stas-prokopiev/binance_historical_data/tree/master): included data from 2017 to Now
+- [Kaggle - prasoonkottarathil/btcinusd](https://www.kaggle.com/datasets/prasoonkottarathil/btcinusd): only included data from 2017-2021
+- [Binance API](https://github.com/sammchardy/python-binance/tree/master): only support few candles per request, not suitable for historical data retrieval
+
+**Download Historical Data:**
+- Download historical data from Binance Data Dumper: `python3 data_download.py`
+
+**Retrieve Real-time Data:**
+- sample script can be found in `data_retrieval.py` (later will scheduled executed using MageAI)
+
+## 2. Feature Engineering
+- Coming soon
+
+## 3. Model Training
+- Coming soon
+
+## 4. Model Serving
+- Coming soon
+
+## 5. Model Observability
+- Coming soon
+
+## 6. Model Auto-Retraining
+- Coming soon

--- a/data_download.py
+++ b/data_download.py
@@ -1,0 +1,41 @@
+""" Download historical data from Binance Data Dumper using `binance_historical_data` library.
+CSV data will be downloaded under `./spot/daily` and `./spot/monthly` folders.
+source: https://pypi.org/project/binance-historical-data/
+
+Data format from Binance Data Dumper:
+[
+    [
+        "Open time",  # - Timestamp
+        "Open",
+        "High",
+        "Low",
+        "Close",
+        "Volume",
+        "Close time",  # - Timestamp
+        "Quote asset volume",
+        "Number of trades",
+        "Taker buy base asset volume",
+        "Taker buy quote asset volume",
+        "Ignore",
+    ],
+    ...
+]
+"""
+
+from binance_historical_data import BinanceDataDumper
+
+
+data_dumper = BinanceDataDumper(
+    path_dir_where_to_dump=".",
+    asset_class="spot",  # spot, um, cm
+    data_type="klines",  # aggTrades, klines, trades
+    data_frequency="15m",
+)
+
+# download data to local directory
+data_dumper.dump_data(
+    tickers=['BTCUSDT'],  # `None` means all tickers
+    date_start=None,  # `None` means from the earliest date
+    date_end=None,  # `None` means up to the latest date
+    is_to_update_existing=True
+)

--- a/data_retrieval.py
+++ b/data_retrieval.py
@@ -1,0 +1,17 @@
+import os
+from dotenv import load_dotenv
+
+from utils.binance_client import BinanceClient
+
+
+load_dotenv()  # take environment variables from `.env`
+
+BINANCE_API_KEY = os.getenv('BINANCE_API_KEY')
+BINANCE_API_SECRET = os.getenv('BINANCE_API_SECRET')
+BINANCE_ENABLE_TESTNET = os.getenv('BINANCE_ENABLE_TESTNET')
+
+binance_client = BinanceClient(api_key=BINANCE_API_KEY, api_secret=BINANCE_API_SECRET, testnet=BINANCE_ENABLE_TESTNET)
+
+# get current BTC coin data
+df_info = binance_client.reformat_klines(symbol='BTCUSDT', interval=binance_client.KLINE_INTERVAL_15MINUTE, limit=int(24*60/15))
+print(df_info)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+binance-historical-data==0.1.13
 numpy==1.21.4
 pandas==1.3.5
 pendulum==2.1.2

--- a/utils/binance_client.py
+++ b/utils/binance_client.py
@@ -18,7 +18,6 @@ class BinanceClient(Client):
                  requests_params: Dict[str, str] = None, testnet: bool = False
                  ):
         super(BinanceClient, self).__init__(api_key=api_key, api_secret=api_secret, requests_params=requests_params, testnet=testnet)
-        self.balances = self.get_balances()
 
     def get_balances(self):
         """
@@ -36,7 +35,27 @@ class BinanceClient(Client):
         return symbols
 
     def reformat_klines(self, symbol, interval, start_time: int = None, end_time: int = None, limit: int = None):
-        """create pd.DataFrame and change data type of columns"""
+        """create pd.DataFrame and change data type of columns
+        
+        Response format from Binance API:
+        [
+            [
+                1499040000000,      // Kline open time
+                "0.01634790",       // Open price
+                "0.80000000",       // High price
+                "0.01575800",       // Low price
+                "0.01577100",       // Close price
+                "148976.11427815",  // Volume
+                1499644799999,      // Kline Close time
+                "2434.19055334",    // Quote asset volume
+                308,                // Number of trades
+                "1756.87402397",    // Taker buy base asset volume
+                "28.46694368",      // Taker buy quote asset volume
+                "0"                 // Unused field, ignore.
+            ]
+        ]
+        """
+
         # get klines information
         if start_time and end_time:
             klines_info = self.get_klines(symbol=symbol, interval=interval, startTime=start_time, endTime=end_time)


### PR DESCRIPTION
## Problem
- current BinanceAPI didn't support bulk data download more than 1 month (?)

## Tasks
- integrate with [Binance Data Dumper](https://github.com/stas-prokopiev/binance_historical_data/tree/master) which included historical data from 2017 to Now

## Testing Results
- after ran `python3 data_download.py`, there is 75 months data downloaded to local directory

![Screenshot 2566-11-06 at 03 55 14](https://github.com/thakorneyp11/stock-price-prediction/assets/58812639/067b70d7-471b-43d3-9945-e19d41fbbaca)