### PR TITLE
Hotfix: update download script to create concat CSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 
 .DS_Store
 spot/
+*.csv

--- a/data_download.py
+++ b/data_download.py
@@ -22,6 +22,8 @@ Data format from Binance Data Dumper:
 ]
 """
 
+import os
+import pandas as pd
 from binance_historical_data import BinanceDataDumper
 
 
@@ -39,3 +41,19 @@ data_dumper.dump_data(
     date_end=None,  # `None` means up to the latest date
     is_to_update_existing=True
 )
+
+# get all csv paths
+csv_directory = "spot/monthly/klines/BTCUSDT/15m"
+csv_paths = [os.path.join(csv_directory, csv) for csv in os.listdir(csv_directory)]
+csv_paths = sorted(csv_paths)
+
+# read all `csv_paths` into dataframes and concat them together
+dfs = list()
+for csv_path in csv_paths:
+    df = pd.read_csv(csv_path)
+    df.columns = ['open_time', 'open_price', 'high_price', 'low_price', 'close_price', 'volume', 'close_time', 'quote_asset_volume', 'number_of_trade', 'taker_buy_base_asset_volume', 'taker_buy_quote_asset_volume', 'ignore']
+    dfs.append(df)  
+
+# export to csv
+df_all = pd.concat(dfs)
+df_all.to_csv("dataset/BTCUSDT_15m_Aug2017-Oct2023.csv", index=False)


### PR DESCRIPTION
## Tasks
- post-process data after downloading from Binance Data Dumper and upload 1 final CSV file to `dataset/` directory

## Testing Results
- all data in `spot/monthly/klines/BTCUSDT/15m` is sorted and concated to 1 final CSV file under `dataset/` directory

![Screenshot 2566-11-06 at 04 24 32](https://github.com/thakorneyp11/stock-price-prediction/assets/58812639/6462fee7-8d4e-4140-97d8-b5518b3dc0ab)
